### PR TITLE
Refactor CLI commands into modules

### DIFF
--- a/card_identifier/cli/__init__.py
+++ b/card_identifier/cli/__init__.py
@@ -1,0 +1,1 @@
+from .main import cli

--- a/card_identifier/cli/card_data.py
+++ b/card_identifier/cli/card_data.py
@@ -1,0 +1,35 @@
+import logging
+
+import click
+
+from card_identifier.cards import pokemon
+from card_identifier.data import NAMESPACES
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option("-r", "--refresh", default=False, is_flag=True)
+@click.option("-f", "--force/--no-force", default=False)
+@click.option("-i", "--images/--no-images", default=False)
+@click.option(
+    "-t",
+    "--card-type",
+    type=click.Choice(NAMESPACES, case_sensitive=False),
+    default="pokemon",
+)
+@click.pass_context
+def card_data(ctx, card_type, images, force, refresh):
+    """Manages the card data for the given card type."""
+    logging.info("card-data")
+    if card_type == "pokemon":
+        logger.info("working with Pokémon data!")
+        cm = pokemon.CardManager()
+        if refresh:
+            logging.info("refreshing card data")
+            cm.refresh_data()
+        if images:
+            im = pokemon.ImageManager()
+            logging.info("downloading card images")
+            im.download_card_images(cm.card_data.values(), force)
+            im.refresh_card_image_map()

--- a/card_identifier/cli/create_dataset.py
+++ b/card_identifier/cli/create_dataset.py
@@ -1,0 +1,67 @@
+import logging
+import multiprocessing as mp
+import pickle
+
+import click
+
+from card_identifier.data import (
+    get_dataset_dir,
+    get_pickle_dir,
+    get_image_dir,
+    NAMESPACES,
+)
+from card_identifier.dataset.generator import DEFAULT_OUT_EXT, gen_random_dataset
+from card_identifier.util import load_random_state
+
+logger = logging.getLogger(__name__)
+
+
+def create_random_training_images(num: int, card_type: str, id_filter: str = None):
+    pickle_dir = get_pickle_dir(card_type)
+    dataset_dir = get_dataset_dir(card_type)
+    load_random_state(pickle_dir)
+    with open(pickle_dir.joinpath("card_image_map.pickle"), "rb") as file:
+        logger.debug("opening card_image_map pickle")
+        id_image_map = pickle.load(file)
+    image_dir = get_image_dir(card_type)
+    work = []
+    logger.info("creating work queue")
+    for card_id, path in id_image_map.items():
+        original_path = image_dir.joinpath(path)
+        if not original_path.exists():
+            logger.error(f"image {path} does not exist")
+            continue
+        if id_filter is None or card_id.startswith(id_filter):
+            logger.debug(f"evaluating {card_id} for work")
+            set_id = card_id.split("-")[0]
+            save_path = dataset_dir.joinpath(f"{set_id}/{card_id}")
+            if not save_path.exists():
+                save_path.mkdir(parents=True)
+                save_num = num
+            else:
+                save_num = num - len(list(save_path.glob(f"*.{DEFAULT_OUT_EXT}")))
+                if save_num <= 0:
+                    continue
+            logger.info(
+                f"adding {card_id} to work, generating {save_num} images"
+            )
+            work.append((image_dir.joinpath(path), save_path, save_num))
+    with mp.Pool(processes=None) as pool:
+        logger.info("starting gen_dataset in pool")
+        pool.starmap(gen_random_dataset, work)
+
+
+@click.command()
+@click.option("-f", "--str-filter", type=str, default=None)
+@click.option("-n", "--number-of-images", type=int, default=100)
+@click.option(
+    "-t",
+    "--card-type",
+    type=click.Choice(NAMESPACES, case_sensitive=False),
+    default="pokemon",
+)
+@click.pass_context
+def create_dataset(ctx, card_type, number_of_images, str_filter):
+    """Creates a random dataset of the given size for the given card type."""
+    mp.set_start_method("spawn")
+    create_random_training_images(number_of_images, card_type, str_filter)

--- a/card_identifier/cli/main.py
+++ b/card_identifier/cli/main.py
@@ -1,62 +1,10 @@
 import logging
-import multiprocessing as mp
-import pickle
-import random
 
 import click
 
-from card_identifier.data import (
-    get_dataset_dir,
-    get_pickle_dir,
-    get_image_dir,
-    NAMESPACES,
-)
-from card_identifier.dataset.generator import DEFAULT_OUT_EXT, gen_random_dataset
-from card_identifier.cards import pokemon
-from card_identifier.util import setup_logging, load_random_state
+from card_identifier.util import setup_logging
 
 logger = logging.getLogger("card_identifier.cli")
-
-
-def create_random_training_images(num: int, card_type: str, id_filter: str = None):
-    pickle_dir = get_pickle_dir(card_type)
-    dataset_dir = get_dataset_dir(card_type)
-    load_random_state(pickle_dir)
-    with open(pickle_dir.joinpath("card_image_map.pickle"), "rb") as file:
-        logger.debug("opening card_image_map pickle")
-        id_image_map = pickle.load(file)
-        # TODO: figure out how to sort id_image_map
-    image_dir = get_image_dir(card_type)
-    work = []
-    logger.info("creating work queue")
-    for card_id, path in id_image_map.items():
-        original_path = image_dir.joinpath(path)
-        if not original_path.exists():
-            logger.error(f"image {path} does not exist")
-            continue
-        if id_filter is None or card_id.startswith(id_filter):
-            logger.debug(f"evaluating {card_id} for work")
-            set_id = card_id.split("-")[0]
-            save_path = dataset_dir.joinpath(
-                f"{set_id}/{card_id}")
-            if not save_path.exists():
-                save_path.mkdir(parents=True)
-                save_num = num
-            else:
-                save_num = num - len(list(save_path.glob(f"*.{DEFAULT_OUT_EXT}")))
-                if save_num <= 0:
-                    continue
-            logger.info(f"adding {card_id} to work, generating {save_num} images")
-            work.append(
-                (
-                    image_dir.joinpath(path),
-                    save_path,
-                    save_num,
-                )
-            )
-    with mp.Pool(processes=None) as pool:
-        logger.info("starting gen_dataset in pool")
-        pool.starmap(gen_random_dataset, work)
 
 
 @click.group()
@@ -68,81 +16,15 @@ def cli(ctx, debug):
     setup_logging(debug)
 
 
-@cli.command()
-@click.option("-r", "--refresh", default=False, is_flag=True)
-@click.option("-f / ", "--force/--no-force", default=False)
-@click.option("-i / ", "--images/--no-images", default=False)
-@click.option("-t", "--card-type",
-              type=click.Choice(NAMESPACES, case_sensitive=False),
-              default="pokemon")
-@click.pass_context
-def card_data(ctx, card_type, images, force, refresh):
-    """Manages the card data for the given card type"""
-    logging.info("card-data")
-    if card_type == "pokemon":
-        logger.info("working with Pokémon data!")
-        cm = pokemon.CardManager()
-        if refresh:
-            logging.info("refreshing card data")
-            cm.refresh_data()
-        if images:
-            im = pokemon.ImageManager()
-            logging.info("downloading card images")
-            im.download_card_images(cm.card_data.values(), force)
-            im.refresh_card_image_map()
+from .card_data import card_data
+from .create_dataset import create_dataset
+from .trim_dataset import trim_dataset
+from .random_state import save_random_state
 
-
-@cli.command()
-@click.option("-f", "--str-filter", type=str, default=None)
-@click.option("-n", "--number-of-images", type=int, default=100)
-@click.option("-t", "--card-type",
-              type=click.Choice(NAMESPACES, case_sensitive=False),
-              default="pokemon")
-@click.pass_context
-def create_dataset(ctx, card_type, number_of_images, str_filter):
-    """Creates a random dataset of the given size for the given card type"""
-    mp.set_start_method("spawn")
-    create_random_training_images(number_of_images, card_type, str_filter)
-
-
-@cli.command()
-@click.option("-n", "--number-of-images", type=int, default=100)
-@click.option("-t", "--card-type",
-              type=click.Choice(NAMESPACES, case_sensitive=False),
-              default="pokemon")
-@click.pass_context
-def trim_dataset(ctx, card_type, number_of_images):
-    """Trims the dataset to the given number of images per card"""
-    pickle_dir = get_pickle_dir(card_type)
-    dataset_dir = get_dataset_dir(card_type)
-    load_random_state(pickle_dir)
-    for set_dir in dataset_dir.glob('*'):
-        if set_dir.is_dir():
-            for image_dir in set_dir.glob('*'):
-                if image_dir.is_dir():
-                    images = list(image_dir.glob(f'*.{DEFAULT_OUT_EXT}'))
-                    if len(images) > number_of_images:
-                        random.shuffle(images)
-                        for image in images[number_of_images:]:
-                            image.unlink()
-
-
-@cli.command()
-@click.option("-s", "--seed", type=int, default=None)
-@click.option("-t", "--card-type",
-              type=click.Choice(NAMESPACES, case_sensitive=False),
-              default="pokemon")
-@click.pass_context
-def save_random_state(ctx, card_type, seed):
-    """Saves the random state to a pickle file"""
-    pickle_dir = get_pickle_dir(card_type)
-    with open(pickle_dir.joinpath("random_state.pickle"), "wb") as file:
-        if seed is not None:
-            random.seed(seed)
-        else:
-            random.seed()
-        logger.info("saving random state")
-        pickle.dump(random.getstate(), file)
+cli.add_command(card_data)
+cli.add_command(create_dataset)
+cli.add_command(trim_dataset)
+cli.add_command(save_random_state)
 
 
 def run():

--- a/card_identifier/cli/random_state.py
+++ b/card_identifier/cli/random_state.py
@@ -1,0 +1,30 @@
+import logging
+import pickle
+import random
+
+import click
+
+from card_identifier.data import get_pickle_dir, NAMESPACES
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="save-random-state")
+@click.option("-s", "--seed", type=int, default=None)
+@click.option(
+    "-t",
+    "--card-type",
+    type=click.Choice(NAMESPACES, case_sensitive=False),
+    default="pokemon",
+)
+@click.pass_context
+def save_random_state(ctx, card_type, seed):
+    """Saves the random state to a pickle file."""
+    pickle_dir = get_pickle_dir(card_type)
+    with open(pickle_dir.joinpath("random_state.pickle"), "wb") as file:
+        if seed is not None:
+            random.seed(seed)
+        else:
+            random.seed()
+        logger.info("saving random state")
+        pickle.dump(random.getstate(), file)

--- a/card_identifier/cli/trim_dataset.py
+++ b/card_identifier/cli/trim_dataset.py
@@ -1,0 +1,35 @@
+import logging
+import random
+
+import click
+
+from card_identifier.data import get_dataset_dir, get_pickle_dir, NAMESPACES
+from card_identifier.dataset.generator import DEFAULT_OUT_EXT
+from card_identifier.util import load_random_state
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option("-n", "--number-of-images", type=int, default=100)
+@click.option(
+    "-t",
+    "--card-type",
+    type=click.Choice(NAMESPACES, case_sensitive=False),
+    default="pokemon",
+)
+@click.pass_context
+def trim_dataset(ctx, card_type, number_of_images):
+    """Trims the dataset to the given number of images per card."""
+    pickle_dir = get_pickle_dir(card_type)
+    dataset_dir = get_dataset_dir(card_type)
+    load_random_state(pickle_dir)
+    for set_dir in dataset_dir.glob("*"):
+        if set_dir.is_dir():
+            for image_dir in set_dir.glob("*"):
+                if image_dir.is_dir():
+                    images = list(image_dir.glob(f"*.{DEFAULT_OUT_EXT}"))
+                    if len(images) > number_of_images:
+                        random.shuffle(images)
+                        for image in images[number_of_images:]:
+                            image.unlink()


### PR DESCRIPTION
## Summary
- split CLI commands into their own modules
- hook new command modules into the main Click group

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684672feb9c08333a551e2a20ec0b26d