### PR TITLE
Add ImageMeta metadata support for dataset generation

### DIFF
--- a/card_identifier/image/__init__.py
+++ b/card_identifier/image/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 from . import background
 from . import transformers  # noqa: F401
+from .meta import ImageMeta
 
 func_map = {
     "random_solid_color": background.random_solid_color,

--- a/card_identifier/image/meta.py
+++ b/card_identifier/image/meta.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+@dataclass
+class ImageMeta:
+    """Metadata about a generated dataset image."""
+
+    filename: str
+    details: Dict[str, Any]


### PR DESCRIPTION
## Summary
- add new `ImageMeta` dataclass for storing generated image metadata
- expose `ImageMeta` via the image package
- update `gen_random_dataset` to return metadata and save JSON next to output

## Testing
- `python -m pip install -e .`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68471467c5208333b5b12e3311ae9db9