### PR TITLE
Add storage helpers

### DIFF
--- a/card_identifier/cli/random_state.py
+++ b/card_identifier/cli/random_state.py
@@ -1,10 +1,10 @@
 import logging
-import pickle
 import random
 
 import click
 
 from card_identifier.data import get_pickle_dir, NAMESPACES
+from card_identifier.storage import save_random_state as save_state
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +21,9 @@ logger = logging.getLogger(__name__)
 def save_random_state(ctx, card_type, seed):
     """Saves the random state to a pickle file."""
     pickle_dir = get_pickle_dir(card_type)
-    with open(pickle_dir.joinpath("random_state.pickle"), "wb") as file:
-        if seed is not None:
-            random.seed(seed)
-        else:
-            random.seed()
-        logger.info("saving random state")
-        pickle.dump(random.getstate(), file)
+    if seed is not None:
+        random.seed(seed)
+    else:
+        random.seed()
+    logger.info("saving random state")
+    save_state(pickle_dir)

--- a/card_identifier/storage.py
+++ b/card_identifier/storage.py
@@ -1,0 +1,35 @@
+import logging
+import pathlib
+import pickle
+import random
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def save_pickle(obj: Any, path: pathlib.Path) -> None:
+    """Serialize *obj* to *path* using pickle."""
+    with open(path, "wb") as file:
+        pickle.dump(obj, file)
+
+
+def load_pickle(path: pathlib.Path, default: Any | None = None) -> Any | None:
+    """Load a pickle from *path*, returning *default* if the file is missing."""
+    if path.exists():
+        with open(path, "rb") as file:
+            logger.info(f"opening pickle {path}")
+            return pickle.load(file)
+    logger.info(f"not loading pickle: missing {path}")
+    return default
+
+
+def save_random_state(pickle_dir: pathlib.Path) -> None:
+    """Save Python's global random state to *pickle_dir*."""
+    save_pickle(random.getstate(), pickle_dir.joinpath("random_state.pickle"))
+
+
+def load_random_state(pickle_dir: pathlib.Path) -> None:
+    """Load Python's global random state from *pickle_dir* if present."""
+    state = load_pickle(pickle_dir.joinpath("random_state.pickle"))
+    if state is not None:
+        random.setstate(state)

--- a/card_identifier/util.py
+++ b/card_identifier/util.py
@@ -1,11 +1,12 @@
 import logging
 import pathlib
-import pickle
 import random
 from urllib.error import HTTPError
 
 import requests
 from retrying import retry
+
+from .storage import save_pickle, load_pickle
 
 logger = logging.getLogger(__name__)
 
@@ -43,15 +44,13 @@ def download_save_image(url: str, path: pathlib.Path) -> bool:
 
 
 def save_random_state(pickle_dir: pathlib.Path):
-    with open(pickle_dir.joinpath("random_state.pickle"), "wb") as file:
-        pickle.dump(random.getstate(), file)
+    save_pickle(random.getstate(), pickle_dir.joinpath("random_state.pickle"))
 
 
 def load_random_state(pickle_dir: pathlib.Path):
     random_state_pickle = pickle_dir.joinpath("random_state.pickle")
-    if random_state_pickle.exists():
-        with open(random_state_pickle, "rb") as file:
-            logger.info("opening random_state pickle")
-            random.setstate(pickle.load(file))
+    state = load_pickle(random_state_pickle)
+    if state is not None:
+        random.setstate(state)
     else:
         logger.info("not loading random_state: missing")


### PR DESCRIPTION
## Summary
- centralize pickle handling with `storage` module
- use storage helpers for random state and card data storage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471bc542f08333afce1e02c4d83a2a