### PR TITLE
Introduce CardAPI client abstraction

### DIFF
--- a/card_identifier/cards/pokemon/__init__.py
+++ b/card_identifier/cards/pokemon/__init__.py
@@ -1,8 +1,10 @@
 import logging
 import pathlib
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pokemontcgsdk import Card, Set
+
+from .api_client import CardAPIClient, PokemonTCGSDKClient
 
 from card_identifier.cards.base import BaseCardManager
 
@@ -71,7 +73,9 @@ class ImageManager:
 
 class CardManager(BaseCardManager):
     """Manages the card and set data for the Pokémon TCG"""
-    def __init__(self):
+
+    def __init__(self, api_client: Optional[CardAPIClient] = None):
+        self.api_client = api_client or PokemonTCGSDKClient()
         self.card_path = get_pickle_dir("pokemon").joinpath("cards.pickle")
         self.set_path = get_pickle_dir("pokemon").joinpath("sets.pickle")
         self.set_card_path = get_pickle_dir("pokemon").joinpath(
@@ -85,11 +89,11 @@ class CardManager(BaseCardManager):
         if data_item == "cards":
             path = self.card_path
             logger.info("getting cards")
-            items = Card.all
+            items = self.api_client.iter_cards
         elif data_item == "sets":
             path = self.set_path
             logger.info("getting sets")
-            items = Set.all
+            items = self.api_client.iter_sets
         else:
             raise ValueError(f"invalid item: {data_item}")
         if path.exists() and not overwrite:

--- a/card_identifier/cards/pokemon/api_client.py
+++ b/card_identifier/cards/pokemon/api_client.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from pokemontcgsdk import Card, Set
+
+
+class CardAPIClient(Protocol):
+    """Interface for retrieving card and set data."""
+
+    def iter_cards(self) -> Iterable:
+        """Return an iterable of card objects."""
+        ...
+
+    def iter_sets(self) -> Iterable:
+        """Return an iterable of set objects."""
+        ...
+
+
+class PokemonTCGSDKClient:
+    """Implementation of :class:`CardAPIClient` using ``pokemontcgsdk``."""
+
+    def iter_cards(self) -> Iterable:
+        return Card.all()
+
+    def iter_sets(self) -> Iterable:
+        return Set.all()
+
+
+__all__ = ["CardAPIClient", "PokemonTCGSDKClient"]

--- a/tests/test_card_manager.py
+++ b/tests/test_card_manager.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+import pytest
+
+from card_identifier.cards import pokemon
+
+
+class MockClient:
+    def __init__(self):
+        self.cards = [
+            SimpleNamespace(id="c1", set=SimpleNamespace(id="s1")),
+            SimpleNamespace(id="c2", set=SimpleNamespace(id="s2")),
+        ]
+        self.sets = [SimpleNamespace(id="s1"), SimpleNamespace(id="s2")]
+
+    def iter_cards(self):
+        return list(self.cards)
+
+    def iter_sets(self):
+        return list(self.sets)
+
+
+def test_card_manager_uses_api_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("CARDIDENT_DATA_ROOT", str(tmp_path))
+    cm = pokemon.CardManager(api_client=MockClient())
+
+    assert set(cm.card_data.keys()) == {"c1", "c2"}
+    assert set(cm.set_data.keys()) == {"s1", "s2"}
+    assert cm.set_card_map == {"s1": ["c1"], "s2": ["c2"]}


### PR DESCRIPTION
## Summary
- add API client abstraction for Pokemon card data
- let CardManager accept API client dependency
- add tests with mock API client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684735f336fc8333b37b75d31de6846d