### PR TITLE
Improve dataset path checks

### DIFF
--- a/card_identifier/dataset/generator.py
+++ b/card_identifier/dataset/generator.py
@@ -33,7 +33,7 @@ def gen_random_dataset(
     """
     # TODO: Need to handle logging better in multiprocessing.
     setup_logging(False)
-    if not image_path.exists() and image_path.is_file():
+    if not image_path.exists() or not image_path.is_file():
         logger.error(f"Image path does not exist or is not a file: {image_path}")
         return
     if not save_path.exists():

--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -1,0 +1,25 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from card_identifier.dataset import generator
+
+
+def test_gen_random_dataset_invalid_image_path(tmp_path, caplog):
+    image_path = tmp_path / "missing.png"
+    save_path = tmp_path / "out"
+    save_path.mkdir()
+    caplog.set_level(logging.ERROR)
+    result = generator.gen_random_dataset(image_path, save_path, 1)
+    assert result is None
+    assert any(
+        "does not exist or is not a file" in record.message for record in caplog.records
+    )
+
+def test_gen_random_dataset_invalid_save_path(tmp_path):
+    image = tmp_path / "img.png"
+    image.write_bytes(b"fake")
+    save_path = tmp_path / "no_dir" / "sub"
+    with pytest.raises(ValueError):
+        generator.gen_random_dataset(image, save_path, 1)


### PR DESCRIPTION
## Summary
- fix dataset generator's image path existence check
- test error handling for invalid image and save paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684774e47ba88333ab83dcaf6c183ca9