### PR TITLE
Add DatasetBuilder and CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+from click.testing import CliRunner
+
+from card_identifier.cli.main import cli
+
+
+def test_mkdataset_cli_dispatch(monkeypatch):
+    called = {}
+
+    def fake_create(num, card_type, id_filter=None):
+        called['args'] = (num, card_type, id_filter)
+
+    monkeypatch.setattr('card_identifier.cli.create_dataset.create_random_training_images', fake_create)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ['create-dataset', '-n', '5', '-t', 'pokemon', '-f', 's1'])
+    assert result.exit_code == 0, result.output
+    assert called['args'] == (5, 'pokemon', 's1')

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from PIL import Image
+
+from card_identifier.dataset import generator
+
+
+def test_dataset_builder_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("CARDIDENT_DATA_ROOT", str(tmp_path))
+    from card_identifier.config import config
+    config.data_root = Path(tmp_path)
+    config.images_dir = config.data_root / "images" / "originals"
+    config.datasets_dir = config.data_root / "images" / "dataset"
+    config.backgrounds_dir = config.data_root / "backgrounds"
+
+    image_dir = config.images_dir / "pokemon"
+    pickle_dir = config.data_root / "barrel" / "pokemon"
+    image_dir.mkdir(parents=True)
+    pickle_dir.mkdir(parents=True)
+
+    img1 = image_dir / "s1-c1.png"
+    img2 = image_dir / "s2-c2.png"
+    Image.new("RGB", (10, 10), color=(255, 0, 0)).save(img1)
+    Image.new("RGB", (10, 10), color=(0, 255, 0)).save(img2)
+
+    with open(pickle_dir / "card_image_map.pickle", "wb") as fh:
+        import pickle
+        pickle.dump({"s1-c1": "s1-c1.png", "s2-c2": "s2-c2.png"}, fh)
+
+    monkeypatch.setattr(generator.background, "BACKGROUND_TYPES", ["random_solid_color"])
+    monkeypatch.setattr(generator, "func_map", {"random_solid_color": generator.background.random_solid_color})
+    monkeypatch.setattr(generator.transformers, "random_perspective_transform", lambda img, wobble_percent=0.2: (img, {}))
+
+    class DummyPool:
+        def __init__(self, processes=None):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def starmap(self, func, work):
+            for args in work:
+                func(*args)
+
+    monkeypatch.setattr(generator.mp, "Pool", DummyPool)
+    monkeypatch.setattr(generator.mp, "set_start_method", lambda *a, **k: None)
+
+    builder = generator.DatasetBuilder("pokemon", num_images=1)
+    builder.run()
+
+    dataset_dir = config.datasets_dir / "pokemon"
+    for card_id in ["s1-c1", "s2-c2"]:
+        card_dir = dataset_dir / card_id.split("-")[0] / card_id
+        images = list(card_dir.glob("*.png"))
+        metas = list(card_dir.glob("*.json"))
+        assert len(images) == 1
+        assert len(metas) == 1
+        meta = json.loads(metas[0].read_text())
+        assert meta["filename"] == images[0].name
+        assert "details" in meta


### PR DESCRIPTION
## Summary
- add test verifying DatasetBuilder.run creates images and JSON metadata
- add CLI test using Click CliRunner to ensure argument parsing dispatches to create_dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c209f88c833383271b725f9c623b