### PR TITLE
Fix retry_if_http_error check and add test

### DIFF
--- a/card_identifier/util.py
+++ b/card_identifier/util.py
@@ -24,12 +24,14 @@ def setup_logging(debug: bool = False):
 def retry_if_http_error(e: Exception):
     if isinstance(e, HTTPError):
         logger.error(f"HTTP error: {e.code} {e.url}")
-        return HTTPError.code == 429
+        return e.code == 429
 
 
-@retry(retry_on_exception=retry_if_http_error,
-       wait_exponential_multiplier=100,
-       wait_exponential_max=10000)
+@retry(
+    retry_on_exception=retry_if_http_error,
+    wait_exponential_multiplier=100,
+    wait_exponential_max=10000,
+)
 def download_save_image(url: str, path: pathlib.Path) -> bool:
     image = requests.get(url, allow_redirects=True)
     logger.debug(f"downloaded image: {url}")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,16 @@
+import logging
+from urllib.error import HTTPError
+
+from card_identifier.util import retry_if_http_error
+
+
+def test_retry_if_http_error_returns_true_on_429(caplog):
+    err = HTTPError(
+        url="http://example.com", code=429, msg="Too Many Requests", hdrs=None, fp=None
+    )
+    caplog.set_level(logging.ERROR)
+    assert retry_if_http_error(err) is True
+    assert any(
+        "HTTP error: 429 http://example.com" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- fix `retry_if_http_error` to check the error's status code
- test 429 retry logic

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6847cdf6cc7c8333b4134d75806bd01a