### PR TITLE
Fix dataset id scanning

### DIFF
--- a/card_identifier/dataset/__init__.py
+++ b/card_identifier/dataset/__init__.py
@@ -17,6 +17,7 @@ logger = logging.getLogger("card_identifier.dataset")
 
 class DatasetManager:
     """Manages the image dataset for training the model on the specified TCG"""
+
     CARD_IMAGE_MAP = "card_image_map.pickle"
 
     def __init__(self, namespace: str):
@@ -46,7 +47,11 @@ class DatasetManager:
         """Creates a map of card id to image path for all images in the dataset_dir"""
         card_dataset_map = {}
         for img in self.dataset_dir.glob("**/*.png"):
-            _id = img.parts[5]
+            rel_parts = img.relative_to(self.dataset_dir).parts
+            if len(rel_parts) < 2:
+                logger.error(f"unexpected dataset path: {img}")
+                continue
+            _id = rel_parts[1]
             if not card_dataset_map.get(_id):
                 card_dataset_map[_id] = {"num_img": 0, "img_paths": []}
             card_dataset_map[_id]["img_paths"].append(pathlib.Path(img))

--- a/tests/test_dataset_scan.py
+++ b/tests/test_dataset_scan.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from card_identifier.dataset import DatasetManager
+
+from tests.test_dataset_symlinks import _create_dataset
+
+
+def test_scan_dataset_dir_deep_path(tmp_path, monkeypatch):
+    deep_root = tmp_path / "some" / "deep" / "structure"
+    monkeypatch.setenv("CARDIDENT_DATA_ROOT", str(deep_root))
+    from card_identifier.config import config
+
+    config.data_root = deep_root
+    config.images_dir = config.data_root / "images" / "originals"
+    config.datasets_dir = config.data_root / "images" / "dataset"
+
+    dataset_root = _create_dataset(deep_root)
+
+    dm = DatasetManager("pokemon")
+    result = dm.scan_dataset_dir()
+
+    assert set(result.keys()) == {"s1-c1", "s2-c2"}
+    assert result["s1-c1"]["num_img"] == 1
+    assert dataset_root / "s1" / "s1-c1" / "img1.png" in result["s1-c1"]["img_paths"]
+    assert result["s2-c2"]["num_img"] == 1
+    assert dataset_root / "s2" / "s2-c2" / "img2.png" in result["s2-c2"]["img_paths"]


### PR DESCRIPTION
## Summary
- fix dataset manager image scanning to parse IDs relative to dataset dir
- test scanning at varying dataset path depth

## Testing
- `pytest -n auto` *(fails: ModuleNotFoundError: No module named 'pokemontcgsdk')*

------
https://chatgpt.com/codex/tasks/task_e_6847cf93b0488333bc06a1bc930e6346