### PR TITLE
Consolidate random state helpers

### DIFF
--- a/card_identifier/cli/trim_dataset.py
+++ b/card_identifier/cli/trim_dataset.py
@@ -5,7 +5,7 @@ import click
 
 from card_identifier.data import get_dataset_dir, get_pickle_dir, NAMESPACES
 from card_identifier.dataset.generator import DEFAULT_OUT_EXT
-from card_identifier.util import load_random_state
+from card_identifier.storage import load_random_state
 
 logger = logging.getLogger(__name__)
 

--- a/card_identifier/dataset/generator.py
+++ b/card_identifier/dataset/generator.py
@@ -12,7 +12,8 @@ import pickle
 
 from card_identifier.image import transformers, background, func_map, ImageMeta
 from card_identifier.data import get_dataset_dir, get_image_dir, get_pickle_dir
-from card_identifier.util import setup_logging, load_random_state
+from card_identifier.util import setup_logging
+from card_identifier.storage import load_random_state
 
 DEFAULT_WORKING_SIZE: Tuple[int, int] = (1024, 1024)
 DEFAULT_OUT_SIZE: Tuple[int, int] = (224, 224)

--- a/card_identifier/util.py
+++ b/card_identifier/util.py
@@ -1,12 +1,9 @@
 import logging
 import pathlib
-import random
 from urllib.error import HTTPError
 
 import requests
 from retrying import retry
-
-from .storage import save_pickle, load_pickle
 
 logger = logging.getLogger(__name__)
 
@@ -43,16 +40,3 @@ def download_save_image(url: str, path: pathlib.Path) -> bool:
     else:
         logger.error(f"error retrieving image: {url}")
         return False
-
-
-def save_random_state(pickle_dir: pathlib.Path):
-    save_pickle(random.getstate(), pickle_dir.joinpath("random_state.pickle"))
-
-
-def load_random_state(pickle_dir: pathlib.Path):
-    random_state_pickle = pickle_dir.joinpath("random_state.pickle")
-    state = load_pickle(random_state_pickle)
-    if state is not None:
-        random.setstate(state)
-    else:
-        logger.info("not loading random_state: missing")


### PR DESCRIPTION
## Summary
- centralize `save_random_state` and `load_random_state` in `storage.py`
- update imports to new location
- drop unused helpers from `util`

## Testing
- `black .`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6848a9217ec48333b2a9991466f5ec97