### PR TITLE
Add exports for CLI and image modules

### DIFF
--- a/card_identifier/cli/__init__.py
+++ b/card_identifier/cli/__init__.py
@@ -1,1 +1,3 @@
 from .main import cli
+
+__all__ = ["cli"]

--- a/card_identifier/image/__init__.py
+++ b/card_identifier/image/__init__.py
@@ -10,3 +10,5 @@ func_map = {
 }
 
 logger = logging.getLogger("card_identifier.image")
+
+__all__ = ["func_map", "ImageMeta"]


### PR DESCRIPTION
## Summary
- expose `cli` in CLI package
- expose `func_map` and `ImageMeta` in image package

## Testing
- `black card_identifier/cli/__init__.py card_identifier/image/__init__.py`
- `pytest -n auto` *(fails: ModuleNotFoundError: No module named 'pokemontcgsdk')*

------
https://chatgpt.com/codex/tasks/task_e_6848b88f247483338e9c0c912c8e5f12