### PR TITLE
Fix delegate loading

### DIFF
--- a/scripts/label_image.py
+++ b/scripts/label_image.py
@@ -21,6 +21,13 @@ import numpy as np
 from PIL import Image
 import tensorflow as tf
 
+try:
+    from tflite_runtime.interpreter import (
+        load_delegate as tflite_load_delegate,
+    )
+except ImportError:  # pragma: no cover - optional dependency not installed
+    tflite_load_delegate = tf.lite.experimental.load_delegate
+
 
 def load_labels(filename):
     with open(filename, "r") as f:
@@ -81,7 +88,7 @@ if __name__ == "__main__":
                 args.ext_delegate, ext_delegate_options
             )
         )
-        ext_delegate = [tflite.load_delegate(args.ext_delegate, ext_delegate_options)]
+        ext_delegate = [tflite_load_delegate(args.ext_delegate, ext_delegate_options)]
 
     interpreter = tf.lite.Interpreter(
         model_path=args.model_file,

--- a/tests/test_label_image.py
+++ b/tests/test_label_image.py
@@ -1,0 +1,24 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("tensorflow") is None,
+    reason="TensorFlow not installed",
+)
+def test_label_image_help_runs():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "label_image.py"
+    result = subprocess.run(
+        [
+            "python",
+            str(script),
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "image to be classified" in result.stdout


### PR DESCRIPTION
## Summary
- fix delegate loading fallback in `label_image`
- test that the script runs with `--help`

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6848bf8aa9608333846d1c7c1d6681f8