### PR TITLE
Validate backgrounds dir before selecting image

### DIFF
--- a/card_identifier/image/background.py
+++ b/card_identifier/image/background.py
@@ -18,7 +18,26 @@ def random_solid_color(size: tuple[int, int], meta) -> Image.Image:
 
 
 def random_bg_image(size: tuple[int, int], meta) -> Image.Image:
-    bg_image = Image.open(random.choice([i for i in config.backgrounds_dir.glob("*")]))
+    """Return a random background image resized to ``size``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``config.backgrounds_dir`` does not exist or contains no images.
+    """
+
+    if not config.backgrounds_dir.exists():
+        raise FileNotFoundError(
+            f"backgrounds directory does not exist: {config.backgrounds_dir}"
+        )
+
+    images = [p for p in config.backgrounds_dir.glob("*") if p.is_file()]
+    if not images:
+        raise FileNotFoundError(
+            f"no background images found in {config.backgrounds_dir}"
+        )
+
+    bg_image = Image.open(random.choice(images))
     meta["bg_image"] = bg_image.filename
     img = Image.new("RGBA", size)
     img.paste(bg_image.resize(size), (0, 0))

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,0 +1,12 @@
+import pytest
+
+from card_identifier.config import config
+from card_identifier.image import background
+
+
+def test_random_bg_image_missing_dir(tmp_path):
+    """random_bg_image should raise when background dir missing or empty."""
+    # Use a path that does not exist
+    config.backgrounds_dir = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError):
+        background.random_bg_image((10, 10), {})


### PR DESCRIPTION
## Summary
- validate that the configured backgrounds directory exists and contains images
- raise `FileNotFoundError` when missing
- add test for failure case

## Testing
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_684909936a648333bbf3ae02605af158