### PR TITLE
Implement lru_cache for get_legal_sets

### DIFF
--- a/card_identifier/cards/pokemon/__init__.py
+++ b/card_identifier/cards/pokemon/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+from functools import lru_cache
 from typing import Dict, List, Optional
 
 from pokemontcgsdk import Card, Set
@@ -14,7 +15,10 @@ from .api_client import CardAPIClient, PokemonTCGSDKClient
 logger = logging.getLogger("card_identifier.pokemon")
 
 
+@lru_cache(maxsize=1)
 def get_legal_sets():
+    """Return the set IDs that are legal in Standard or Expanded play."""
+
     return set((s.id for s in Set.where(q="legalities.standard:legal"))).union(
         set((s.id for s in Set.where(q="legalities.expanded:legal")))
     )

--- a/tests/test_get_legal_sets.py
+++ b/tests/test_get_legal_sets.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from card_identifier.cards import pokemon
+
+
+def test_get_legal_sets_cached(monkeypatch):
+    pokemon.get_legal_sets.cache_clear()
+
+    calls = []
+
+    def fake_where(q):
+        calls.append(q)
+        return [SimpleNamespace(id=f"{q}-id")]
+
+    monkeypatch.setattr("pokemontcgsdk.Set.where", fake_where)
+
+    result1 = pokemon.get_legal_sets()
+    result2 = pokemon.get_legal_sets()
+
+    assert result1 == {
+        "legalities.standard:legal-id",
+        "legalities.expanded:legal-id",
+    }
+    assert result1 is result2
+    assert calls == ["legalities.standard:legal", "legalities.expanded:legal"]


### PR DESCRIPTION
## Summary
- cache `pokemon.get_legal_sets` via `functools.lru_cache`
- add regression test verifying that `pokemontcgsdk.Set.where` is called only once

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68490c8194788333807fba840ca3017e