### PR TITLE
Add noise augmentation option

### DIFF
--- a/card_identifier/image/transformers.py
+++ b/card_identifier/image/transformers.py
@@ -179,6 +179,7 @@ def random_solarize(img: Image.Image) -> Tuple[Image.Image, dict]:
 
 def random_random_transformer(img: Image.Image) -> Tuple[Image.Image, dict]:
     xformers = [
+        random_add_noise,
         random_autocontrast,
         random_posterize,
         random_solarize,

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -81,3 +81,13 @@ def test_random_solarize_size_and_meta():
     assert meta["transformer"] == "solarize"
     assert 1 <= meta["threshold"] <= 128
     assert meta["method"] == "PIL.ImageOps.solarize"
+
+
+def test_random_add_noise_size_and_meta():
+    img = create_image()
+    out, meta = transformers.random_add_noise(img)
+    assert out.size == img.size
+    assert meta["transformer"] == "noise"
+    assert 0.001 <= meta["amount"] <= 0.01
+    assert meta["mode"] == "s&p"
+    assert meta["method"] == "skimage.util.random_noise"


### PR DESCRIPTION
## Summary
- include `random_add_noise` in `random_random_transformer`
- test noise augmentation

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_684916f4d2e083339a4289ac6d97ff16