### PR TITLE
Fix image opening in dataset generator

### DIFF
--- a/card_identifier/dataset/generator.py
+++ b/card_identifier/dataset/generator.py
@@ -40,8 +40,8 @@ def gen_random_dataset(
     if not save_path.exists():
         raise ValueError(f"Save path does not exist: {save_path}")
     logger.info(f"Generating {dataset_size} images from {image_path}")
-    src_image = Image.open(image_path)
-    src_image = src_image.convert(mode="RGBA")
+    with Image.open(image_path) as img:
+        src_image = img.convert(mode="RGBA")
     metas: List[ImageMeta] = []
     for iteration in range(0, dataset_size):
         logger.debug(f"Generating image {image_path} {iteration} of {dataset_size}")


### PR DESCRIPTION
## Summary
- ensure `gen_random_dataset` closes image files by using a context manager

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68491dffd0248333b60832448ec7d192