### PR TITLE
Add transformer metadata test

### DIFF
--- a/tests/test_dataset_generator.py
+++ b/tests/test_dataset_generator.py
@@ -58,3 +58,42 @@ def test_gen_random_dataset_no_fd_leak(tmp_path, monkeypatch):
 
     assert len(result) == 3
     assert before == after
+
+
+def test_gen_random_dataset_with_transform_meta(tmp_path, monkeypatch):
+    """gen_random_dataset should include transformer metadata when triggered."""
+    from PIL import Image
+
+    image_path = tmp_path / "img.png"
+    Image.new("RGB", (10, 10), color=(255, 0, 0)).save(image_path)
+    save_path = tmp_path / "out"
+    save_path.mkdir()
+
+    from card_identifier.config import config
+
+    config.backgrounds_dir = tmp_path
+    monkeypatch.setattr(
+        generator.background, "BACKGROUND_TYPES", ["random_solid_color"]
+    )
+    monkeypatch.setattr(
+        generator,
+        "func_map",
+        {"random_solid_color": generator.background.random_solid_color},
+    )
+    monkeypatch.setattr(
+        generator.transformers,
+        "random_perspective_transform",
+        lambda img, wobble_percent=0.2: (img, {}),
+    )
+
+    # Always trigger the random transformer
+    monkeypatch.setattr(generator.random, "random", lambda: 0.0)
+    monkeypatch.setattr(generator.transformers.random, "random", lambda: 0.0)
+    monkeypatch.setattr(generator.transformers.random, "choice", lambda seq: seq[0])
+
+    metas = generator.gen_random_dataset(image_path, save_path, 1, xform=True)
+
+    assert len(metas) == 1
+    meta = metas[0].details
+    assert meta["transform"] is True
+    assert "transformer" in meta


### PR DESCRIPTION
## Summary
- check that transformer metadata is emitted when random transform is forced

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6849248a34dc83339ce9d6bf2cda46b0