### PR TITLE
Add dev extras mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,15 @@ pytest-xdist = "^3.7.0"
 ruff = "^0.4.3"
 pre-commit = "^3.7.0"
 
+[tool.poetry.extras]
+dev = [
+    "streamlit",
+    "pytest",
+    "pytest-xdist",
+    "ruff",
+    "pre-commit",
+]
+
 [tool.poetry.scripts]
 mkdataset = "card_identifier.cli.main:run"
 


### PR DESCRIPTION
## Summary
- map dev dependencies to a `dev` extra in `pyproject.toml`

## Testing
- `black .`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68492905ac448333b0ab0a57a7e7c860