### PR TITLE
Update streamlit import

### DIFF
--- a/scripts/streamlit/foo.py
+++ b/scripts/streamlit/foo.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from card_identifier import pokemon
+from card_identifier.cards import pokemon
 
 st.title("Card Identifier")
 collection_type = st.sidebar.selectbox("Collection Type", ["Pokemon"])


### PR DESCRIPTION
## Summary
- fix import of `pokemon` in Streamlit example

## Testing
- `python scripts/streamlit/foo.py` *(fails later fetching data but no import error)*
- `black scripts/streamlit/foo.py`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_684929abedd48333b50c8a78f46a43bc