### PR TITLE
Fix bg image leak

### DIFF
--- a/card_identifier/image/background.py
+++ b/card_identifier/image/background.py
@@ -37,10 +37,11 @@ def random_bg_image(size: tuple[int, int], meta) -> Image.Image:
             f"no background images found in {config.backgrounds_dir}"
         )
 
-    bg_image = Image.open(random.choice(images))
-    meta["bg_image"] = bg_image.filename
-    img = Image.new("RGBA", size)
-    img.paste(bg_image.resize(size), (0, 0))
+    path = random.choice(images)
+    with Image.open(path) as bg_image:
+        meta["bg_image"] = bg_image.filename
+        img = Image.new("RGBA", size)
+        img.paste(bg_image.resize(size), (0, 0))
     return img
 
 

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -10,3 +10,22 @@ def test_random_bg_image_missing_dir(tmp_path):
     config.backgrounds_dir = tmp_path / "missing"
     with pytest.raises(FileNotFoundError):
         background.random_bg_image((10, 10), {})
+
+
+def test_random_bg_image_no_fd_leak(tmp_path):
+    """random_bg_image should not leak file descriptors."""
+    import os
+    from PIL import Image
+
+    config.backgrounds_dir = tmp_path
+    for i in range(3):
+        Image.new("RGB", (10, 10), color=(i, i, i)).save(tmp_path / f"{i}.png")
+
+    before = len(os.listdir("/proc/self/fd"))
+    meta = {}
+    img = background.random_bg_image((5, 5), meta)
+    after = len(os.listdir("/proc/self/fd"))
+
+    assert img.size == (5, 5)
+    assert "bg_image" in meta
+    assert before == after


### PR DESCRIPTION
## Summary
- ensure `random_bg_image` cleans up opened images
- add regression test checking file descriptors

## Testing
- `black .`
- `pytest -n auto`


------
https://chatgpt.com/codex/tasks/task_e_684929b465a48333b0874e78dbf85607