### PR TITLE
Add concise CLI function docstrings

### DIFF
--- a/card_identifier/cli/card_data.py
+++ b/card_identifier/cli/card_data.py
@@ -20,7 +20,15 @@ logger = logging.getLogger(__name__)
 )
 @click.pass_context
 def card_data(ctx, card_type, images, force, refresh):
-    """Manages the card data for the given card type."""
+    """Manage metadata and images for a particular card namespace.
+
+    Args:
+        ctx (click.Context): CLI context.
+        card_type (str): Namespace of cards to manage.
+        images (bool): Download card images if ``True``.
+        force (bool): Overwrite existing images when downloading.
+        refresh (bool): Refresh cached card metadata before processing.
+    """
     logging.info("card-data")
     if card_type == "pokemon":
         logger.info("working with Pokémon data!")

--- a/card_identifier/cli/create_dataset.py
+++ b/card_identifier/cli/create_dataset.py
@@ -9,7 +9,14 @@ logger = logging.getLogger(__name__)
 
 
 def create_random_training_images(num: int, card_type: str, id_filter: str = None):
-    """Build a work queue and generate the dataset."""
+    """Generate a dataset of random card images.
+
+    Args:
+        num (int): Number of images to create.
+        card_type (str): Namespace of cards to sample from.
+        id_filter (str, optional): Restrict to card IDs containing this
+            substring.
+    """
     builder = DatasetBuilder(card_type=card_type, num_images=num, id_filter=id_filter)
     builder.run()
 
@@ -25,5 +32,12 @@ def create_random_training_images(num: int, card_type: str, id_filter: str = Non
 )
 @click.pass_context
 def create_dataset(ctx, card_type, number_of_images, str_filter):
-    """Creates a random dataset of the given size for the given card type."""
+    """CLI entry point for generating a random training set.
+
+    Args:
+        ctx (click.Context): CLI context.
+        card_type (str): Namespace of cards to sample from.
+        number_of_images (int): Total number of images to produce.
+        str_filter (str | None): Optional substring filter for card IDs.
+    """
     create_random_training_images(number_of_images, card_type, str_filter)

--- a/card_identifier/cli/random_state.py
+++ b/card_identifier/cli/random_state.py
@@ -19,7 +19,13 @@ logger = logging.getLogger(__name__)
 )
 @click.pass_context
 def save_random_state(ctx, card_type, seed):
-    """Saves the random state to a pickle file."""
+    """Persist Python's RNG state for reproducible dataset generation.
+
+    Args:
+        ctx (click.Context): CLI context.
+        card_type (str): Namespace of cards associated with the state.
+        seed (int | None): Seed to initialize ``random`` before saving.
+    """
     pickle_dir = get_pickle_dir(card_type)
     if seed is not None:
         random.seed(seed)

--- a/card_identifier/cli/trim_dataset.py
+++ b/card_identifier/cli/trim_dataset.py
@@ -20,7 +20,13 @@ logger = logging.getLogger(__name__)
 )
 @click.pass_context
 def trim_dataset(ctx, card_type, number_of_images):
-    """Trims the dataset to the given number of images per card."""
+    """Remove excess images from a dataset directory.
+
+    Args:
+        ctx (click.Context): CLI context.
+        card_type (str): Namespace of cards to trim.
+        number_of_images (int): Maximum images to keep per card.
+    """
     pickle_dir = get_pickle_dir(card_type)
     dataset_dir = get_dataset_dir(card_type)
     load_random_state(pickle_dir)


### PR DESCRIPTION
## Summary
- document CLI helpers in `card_identifier.cli`

## Testing
- `ruff check card_identifier/cli/card_data.py card_identifier/cli/create_dataset.py card_identifier/cli/trim_dataset.py card_identifier/cli/random_state.py`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68499b0417548333af3f745189de32ac