### PR TITLE
Fix ruff import order in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 target-version = "py310"
 line-length = 88
+exclude = ["notebooks/*"]
 
 [tool.ruff.lint]
 extend-select = ["I"]

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -15,6 +15,7 @@ def test_random_bg_image_missing_dir(tmp_path):
 def test_random_bg_image_no_fd_leak(tmp_path):
     """random_bg_image should not leak file descriptors."""
     import os
+
     from PIL import Image
 
     config.backgrounds_dir = tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
 
 from card_identifier.cli.main import cli
 


### PR DESCRIPTION
## Summary
- reorder imports in CLI and background tests
- exclude notebooks from ruff checks

## Testing
- `pytest -n auto`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68499adda2f883338facdd1421d7bdbd