### PR TITLE
Ignore notebooks in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 target-version = "py310"
 line-length = 88
+extend-exclude = ["notebooks/*"]
 
 [tool.ruff.lint]
 extend-select = ["I"]


### PR DESCRIPTION
## Summary
- exclude the notebooks directory from ruff checks

## Testing
- `ruff check .`
- `pytest -n auto` *(fails: ModuleNotFoundError: No module named 'pokemontcgsdk')*

------
https://chatgpt.com/codex/tasks/task_e_68499aea9cb48333a4d29134ea12c281