### PR TITLE
Add documentation and hints to CLI utilities

### DIFF
--- a/card_identifier/cli/card_data.py
+++ b/card_identifier/cli/card_data.py
@@ -19,15 +19,28 @@ logger = logging.getLogger(__name__)
     default="pokemon",
 )
 @click.pass_context
-def card_data(ctx, card_type, images, force, refresh):
+def card_data(
+    ctx: click.Context, card_type: str, images: bool, force: bool, refresh: bool
+) -> None:
     """Manage metadata and images for a particular card namespace.
 
-    Args:
-        ctx (click.Context): CLI context.
-        card_type (str): Namespace of cards to manage.
-        images (bool): Download card images if ``True``.
-        force (bool): Overwrite existing images when downloading.
-        refresh (bool): Refresh cached card metadata before processing.
+    Parameters
+    ----------
+    ctx:
+        ``click`` context object.
+    card_type:
+        Namespace of cards to manage.
+    images:
+        Download card images when ``True``.
+    force:
+        Overwrite any existing image files when downloading.
+    refresh:
+        Refresh cached card metadata before processing.
+
+    Returns
+    -------
+    None
+        Card metadata and images are written to disk as a side effect.
     """
     logging.info("card-data")
     if card_type == "pokemon":

--- a/card_identifier/cli/create_dataset.py
+++ b/card_identifier/cli/create_dataset.py
@@ -8,15 +8,30 @@ from card_identifier.dataset.generator import DatasetBuilder
 logger = logging.getLogger(__name__)
 
 
-def create_random_training_images(num: int, card_type: str, id_filter: str = None):
+def create_random_training_images(
+    num: int, card_type: str, id_filter: str | None = None
+) -> None:
     """Generate a dataset of random card images.
 
-    Args:
-        num (int): Number of images to create.
-        card_type (str): Namespace of cards to sample from.
-        id_filter (str, optional): Restrict to card IDs containing this
-            substring.
+    Parameters
+    ----------
+    num:
+        Number of images to create.
+    card_type:
+        Namespace of cards to sample from.
+    id_filter:
+        Restrict the random draw to card IDs containing this substring.
+
+    Returns
+    -------
+    None
+        The generated images are written to the dataset directory.
+
+    Side Effects
+    ------------
+    Creates image files on disk via :class:`~card_identifier.dataset.generator.DatasetBuilder`.
     """
+
     builder = DatasetBuilder(card_type=card_type, num_images=num, id_filter=id_filter)
     builder.run()
 
@@ -31,13 +46,27 @@ def create_random_training_images(num: int, card_type: str, id_filter: str = Non
     default="pokemon",
 )
 @click.pass_context
-def create_dataset(ctx, card_type, number_of_images, str_filter):
+def create_dataset(
+    ctx: click.Context, card_type: str, number_of_images: int, str_filter: str | None
+) -> None:
     """CLI entry point for generating a random training set.
 
-    Args:
-        ctx (click.Context): CLI context.
-        card_type (str): Namespace of cards to sample from.
-        number_of_images (int): Total number of images to produce.
-        str_filter (str | None): Optional substring filter for card IDs.
+    Parameters
+    ----------
+    ctx:
+        ``click`` context object.
+    card_type:
+        Namespace of cards to sample from.
+    number_of_images:
+        Total number of images to produce.
+    str_filter:
+        Optional substring filter used to limit the cards that may be drawn.
+
+    Returns
+    -------
+    None
+        Images are written to the dataset directory via
+        :func:`create_random_training_images`.
     """
+
     create_random_training_images(number_of_images, card_type, str_filter)

--- a/card_identifier/cli/random_state.py
+++ b/card_identifier/cli/random_state.py
@@ -18,13 +18,27 @@ logger = logging.getLogger(__name__)
     default="pokemon",
 )
 @click.pass_context
-def save_random_state(ctx, card_type, seed):
+def save_random_state(ctx: click.Context, card_type: str, seed: int | None) -> None:
     """Persist Python's RNG state for reproducible dataset generation.
 
-    Args:
-        ctx (click.Context): CLI context.
-        card_type (str): Namespace of cards associated with the state.
-        seed (int | None): Seed to initialize ``random`` before saving.
+    Parameters
+    ----------
+    ctx:
+        ``click`` context object.
+    card_type:
+        Namespace of cards associated with the saved state.
+    seed:
+        Seed used to initialize :mod:`random` before persisting the state.  If
+        ``None`` a random seed is chosen.
+
+    Returns
+    -------
+    None
+        The RNG state is written to ``pickle_dir/random_state.pkl``.
+
+    Side Effects
+    ------------
+    Sets the global ``random`` module state and writes it to disk.
     """
     pickle_dir = get_pickle_dir(card_type)
     if seed is not None:

--- a/card_identifier/cli/trim_dataset.py
+++ b/card_identifier/cli/trim_dataset.py
@@ -19,13 +19,27 @@ logger = logging.getLogger(__name__)
     default="pokemon",
 )
 @click.pass_context
-def trim_dataset(ctx, card_type, number_of_images):
+def trim_dataset(ctx: click.Context, card_type: str, number_of_images: int) -> None:
     """Remove excess images from a dataset directory.
 
-    Args:
-        ctx (click.Context): CLI context.
-        card_type (str): Namespace of cards to trim.
-        number_of_images (int): Maximum images to keep per card.
+    Parameters
+    ----------
+    ctx:
+        ``click`` context object.
+    card_type:
+        Namespace of cards to trim.
+    number_of_images:
+        Maximum number of images to keep per card.
+
+    Returns
+    -------
+    None
+        Excess images are removed from the dataset directory as a side effect.
+
+    Side Effects
+    ------------
+    Deletes files from the dataset directory after loading the persisted
+    random state to ensure deterministic trimming.
     """
     pickle_dir = get_pickle_dir(card_type)
     dataset_dir = get_dataset_dir(card_type)


### PR DESCRIPTION
## Summary
- document CLI tools with parameter/return docs and mention side-effects
- provide type hints for CLI entry points

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6849b14acff8833397015bbb0890d081