### PR TITLE
Fix import ordering

### DIFF
--- a/tests/test_dataset_builder_failures.py
+++ b/tests/test_dataset_builder_failures.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from card_identifier.dataset import generator
 
-
 # Test when referenced images are missing
 
 


### PR DESCRIPTION
## Summary
- reorder imports in test_dataset_builder_failures

## Testing
- `ruff check`
- `black --check .`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6849c0be8cd08333b59dbd1f7a46aa5a