### PR TITLE
Handle missing card image map

### DIFF
--- a/card_identifier/dataset/generator.py
+++ b/card_identifier/dataset/generator.py
@@ -102,9 +102,15 @@ class DatasetBuilder:
         load_random_state(self.pickle_dir)
         work: list[tuple[pathlib.Path, pathlib.Path, int]] = []
 
-        with open(self.pickle_dir.joinpath("card_image_map.pickle"), "rb") as file:
-            logger.debug("opening card_image_map pickle")
-            id_image_map = pickle.load(file)
+        card_map = self.pickle_dir.joinpath("card_image_map.pickle")
+        try:
+            with open(card_map, "rb") as file:
+                logger.debug("opening card_image_map pickle")
+                id_image_map = pickle.load(file)
+        except FileNotFoundError as exc:
+            msg = f"card image map not found: {card_map}"
+            logger.error(msg)
+            raise FileNotFoundError(msg) from exc
 
         logger.info("creating work queue")
         for card_id, path in id_image_map.items():

--- a/tests/test_dataset_builder_failures.py
+++ b/tests/test_dataset_builder_failures.py
@@ -2,6 +2,8 @@ import logging
 import pickle
 from pathlib import Path
 
+import pytest
+
 from card_identifier.dataset import generator
 
 # Test when referenced images are missing
@@ -63,3 +65,19 @@ def test_run_no_work_logs_warning(tmp_path, monkeypatch, caplog):
     builder.run()
 
     assert any("no work items generated" in record.message for record in caplog.records)
+
+
+def test_build_work_missing_card_map(tmp_path, monkeypatch):
+    monkeypatch.setenv("CARDIDENT_DATA_ROOT", str(tmp_path))
+    from card_identifier.config import config
+
+    config.data_root = Path(tmp_path)
+    config.images_dir = config.data_root / "images" / "originals"
+    config.datasets_dir = config.data_root / "images" / "dataset"
+    config.backgrounds_dir = config.data_root / "backgrounds"
+
+    # Directories are created by DatasetBuilder
+    builder = generator.DatasetBuilder("pokemon", num_images=1)
+
+    with pytest.raises(FileNotFoundError, match="card image map not found"):
+        builder.build_work()


### PR DESCRIPTION
## Summary
- improve DatasetBuilder.build_work error handling
- test missing card_image_map.pickle failure

## Testing
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_6849cd3adca483338e81350a254db66c