### PR TITLE
Add CI workflow with linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,9 +15,11 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-      - name: Install package
+      - name: Install dependencies
         run: pip install -e '.[dev]'
-      - name: Run pre-commit
-        run: pre-commit run --all-files
-      - name: Run tests
+      - name: Ruff check
+        run: ruff check .
+      - name: Black check
+        run: black --check .
+      - name: Pytest
         run: pytest -n auto


### PR DESCRIPTION
## Summary
- update the CI pipeline to run ruff, black and pytest on PRs and pushes to `main`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -n auto`

------
https://chatgpt.com/codex/tasks/task_e_684a0f3288c48333af84a637fdb06d42